### PR TITLE
Update RabbitMQ Source Connector

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,8 @@ nb-configuration.xml
 # Maven
 log/
 target/
+.mvn/wrapper/maven-wrapper.jar
+.m2
 
 # Python
 *.pyc
@@ -93,3 +95,12 @@ examples/flink/src/main/java/org/apache/flink/avro/generated
 pulsar-flink/src/test/java/org/apache/flink/avro/generated
 pulsar-client/src/test/java/org/apache/pulsar/client/avro/generated
 /build/
+
+test-reports/
+
+# Gradle Enterprise
+.mvn/.gradle-enterprise/
+
+# Emacs
+*~
+*#

--- a/.rc
+++ b/.rc
@@ -1,0 +1,9 @@
+function mvn() {
+    DOCKER_IMAGE=apachepulsar/pulsar-build:ubuntu-20.04
+    DOCKER_RUN_OPTS="--rm -it --network host -v ${PWD}/.m2:/root/.m2 -v ${PWD}:${PWD} -w ${PWD} ${DOCKER_RUN_EXTRA_OPTS}"
+    if [ -n "$ZSH_VERSION" ]; then
+        docker run ${=DOCKER_RUN_OPTS} ${DOCKER_IMAGE} mvn "$@"
+    else
+        docker run ${DOCKER_RUN_OPTS} ${DOCKER_IMAGE} mvn "$@"
+    fi
+}

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,15 @@
+.PHONY: all build test clean
+
+ifndef NODOCKER
+SHELL := BASH_ENV=.rc /bin/bash --noprofile
+endif
+
+all: build test
+
+build: ; mvn clean -pl pulsar-io/rabbitmq install -DskipTests
+
+test: ; mvn -pl pulsar-io/rabbitmq test
+
+clean:
+	mvn clean
+	rm -rf .m2

--- a/pom.xml
+++ b/pom.xml
@@ -1482,6 +1482,7 @@ flexible messaging model and an intuitive client API.</description>
               <excludes>
                 <exclude>LICENSE</exclude>
                 <exclude>NOTICE</exclude>
+                <exclude>Makefile</exclude>
                 <exclude>**/*.txt</exclude>
                 <exclude>**/*.pem</exclude>
                 <exclude>**/*.crt</exclude>

--- a/pulsar-io/rabbitmq/src/main/java/org/apache/pulsar/io/rabbitmq/RabbitMQAbstractConfig.java
+++ b/pulsar-io/rabbitmq/src/main/java/org/apache/pulsar/io/rabbitmq/RabbitMQAbstractConfig.java
@@ -22,6 +22,8 @@ package org.apache.pulsar.io.rabbitmq;
 import com.google.common.base.Preconditions;
 import com.rabbitmq.client.ConnectionFactory;
 import java.io.Serializable;
+import java.security.KeyManagementException;
+import java.security.NoSuchAlgorithmException;
 import lombok.Data;
 import lombok.experimental.Accessors;
 import org.apache.pulsar.io.core.annotations.FieldDoc;
@@ -52,6 +54,12 @@ public class RabbitMQAbstractConfig implements Serializable {
         defaultValue = "5672",
         help = "The RabbitMQ port to connect to")
     private int port = 5672;
+
+    @FieldDoc(
+        required = false,
+        defaultValue = "false",
+        help = "Set to true to establish a secure connection to RabbitMQ")
+    private boolean ssl = false;
 
     @FieldDoc(
         required = true,
@@ -116,7 +124,7 @@ public class RabbitMQAbstractConfig implements Serializable {
         Preconditions.checkNotNull(connectionName, "connectionName property not set.");
     }
 
-    public ConnectionFactory createConnectionFactory() {
+    public ConnectionFactory createConnectionFactory() throws NoSuchAlgorithmException, KeyManagementException {
         ConnectionFactory connectionFactory = new ConnectionFactory();
         connectionFactory.setHost(this.host);
         connectionFactory.setUsername(this.username);
@@ -128,6 +136,9 @@ public class RabbitMQAbstractConfig implements Serializable {
         connectionFactory.setHandshakeTimeout(this.handshakeTimeout);
         connectionFactory.setRequestedHeartbeat(this.requestedHeartbeat);
         connectionFactory.setPort(this.port);
+        if (this.ssl) {
+            connectionFactory.useSslProtocol();
+        }
         return connectionFactory;
     }
 }

--- a/pulsar-io/rabbitmq/src/main/java/org/apache/pulsar/io/rabbitmq/RabbitMQSource.java
+++ b/pulsar-io/rabbitmq/src/main/java/org/apache/pulsar/io/rabbitmq/RabbitMQSource.java
@@ -65,14 +65,15 @@ public class RabbitMQSource extends PushSource<byte[]> {
                 rabbitMQConnection.getPort()
         );
         rabbitMQChannel = rabbitMQConnection.createChannel();
+        AMQP.Queue.DeclareOk queueDeclaration;
         if (rabbitMQSourceConfig.isPassive()) {
-            rabbitMQChannel.queueDeclarePassive(rabbitMQSourceConfig.getQueueName());
+            queueDeclaration = rabbitMQChannel.queueDeclarePassive(rabbitMQSourceConfig.getQueueName());
         } else {
-            rabbitMQChannel.queueDeclare(rabbitMQSourceConfig.getQueueName(),
-                                     rabbitMQSourceConfig.isDurable(),
-                                     rabbitMQSourceConfig.isExclusive(),
-                                     rabbitMQSourceConfig.isAutoDelete(),
-                                     null
+            queueDeclaration = rabbitMQChannel.queueDeclare(rabbitMQSourceConfig.getQueueName(),
+                                                        rabbitMQSourceConfig.isDurable(),
+                                                        rabbitMQSourceConfig.isExclusive(),
+                                                        rabbitMQSourceConfig.isAutoDelete(),
+                                                        null
             );
         }
         logger.info("Setting channel.basicQos({}, {}).",
@@ -82,7 +83,7 @@ public class RabbitMQSource extends PushSource<byte[]> {
         rabbitMQChannel.basicQos(rabbitMQSourceConfig.getPrefetchCount(), rabbitMQSourceConfig.isPrefetchGlobal());
         com.rabbitmq.client.Consumer consumer = new RabbitMQConsumer(this, rabbitMQChannel);
         rabbitMQChannel.basicConsume(rabbitMQSourceConfig.getQueueName(), consumer);
-        logger.info("A consumer for queue {} has been successfully started.", rabbitMQSourceConfig.getQueueName());
+        logger.info("A consumer for queue {} has been successfully started.", queueDeclaration.getQueue());
     }
 
     @Override

--- a/pulsar-io/rabbitmq/src/main/java/org/apache/pulsar/io/rabbitmq/RabbitMQSource.java
+++ b/pulsar-io/rabbitmq/src/main/java/org/apache/pulsar/io/rabbitmq/RabbitMQSource.java
@@ -81,6 +81,11 @@ public class RabbitMQSource extends PushSource<byte[]> {
                 rabbitMQSourceConfig.isPrefetchGlobal()
         );
         rabbitMQChannel.basicQos(rabbitMQSourceConfig.getPrefetchCount(), rabbitMQSourceConfig.isPrefetchGlobal());
+        String exchange = rabbitMQSourceConfig.getExchangeName();
+        String routingKey = rabbitMQSourceConfig.getRoutingKey();
+        if (exchange != null) {
+            rabbitMQChannel.queueBind(queueDeclaration.getQueue(), exchange, routingKey);
+        }
         com.rabbitmq.client.Consumer consumer = new RabbitMQConsumer(this, rabbitMQChannel);
         rabbitMQChannel.basicConsume(rabbitMQSourceConfig.getQueueName(), consumer);
         logger.info("A consumer for queue {} has been successfully started.", queueDeclaration.getQueue());

--- a/pulsar-io/rabbitmq/src/main/java/org/apache/pulsar/io/rabbitmq/RabbitMQSource.java
+++ b/pulsar-io/rabbitmq/src/main/java/org/apache/pulsar/io/rabbitmq/RabbitMQSource.java
@@ -90,7 +90,7 @@ public class RabbitMQSource extends PushSource<byte[]> {
             rabbitMQChannel.queueBind(queueName, exchange, routingKey);
         }
         com.rabbitmq.client.Consumer consumer = new RabbitMQConsumer(this, rabbitMQChannel);
-        rabbitMQChannel.basicConsume(rabbitMQSourceConfig.getQueueName(), consumer);
+        rabbitMQChannel.basicConsume(queueName, consumer);
         logger.info("A consumer for queue {} has been successfully started.", queueName);
     }
 

--- a/pulsar-io/rabbitmq/src/main/java/org/apache/pulsar/io/rabbitmq/RabbitMQSource.java
+++ b/pulsar-io/rabbitmq/src/main/java/org/apache/pulsar/io/rabbitmq/RabbitMQSource.java
@@ -68,7 +68,12 @@ public class RabbitMQSource extends PushSource<byte[]> {
         if (rabbitMQSourceConfig.isPassive()) {
             rabbitMQChannel.queueDeclarePassive(rabbitMQSourceConfig.getQueueName());
         } else {
-            rabbitMQChannel.queueDeclare(rabbitMQSourceConfig.getQueueName(), false, false, false, null);
+            rabbitMQChannel.queueDeclare(rabbitMQSourceConfig.getQueueName(),
+                                     rabbitMQSourceConfig.isDurable(),
+                                     rabbitMQSourceConfig.isExclusive(),
+                                     rabbitMQSourceConfig.isAutoDelete(),
+                                     null
+            );
         }
         logger.info("Setting channel.basicQos({}, {}).",
                 rabbitMQSourceConfig.getPrefetchCount(),

--- a/pulsar-io/rabbitmq/src/main/java/org/apache/pulsar/io/rabbitmq/RabbitMQSourceConfig.java
+++ b/pulsar-io/rabbitmq/src/main/java/org/apache/pulsar/io/rabbitmq/RabbitMQSourceConfig.java
@@ -79,6 +79,18 @@ public class RabbitMQSourceConfig extends RabbitMQAbstractConfig implements Seri
             help = "Set true if the queue should get deleted when the last consumer unsubscribes")
     private boolean autoDelete = false;
 
+    @FieldDoc(
+        required = false,
+        defaultValue = "",
+        help = "The exchange to bind the queue on")
+    private String exchangeName;
+
+    @FieldDoc(
+            required = false,
+            defaultValue = "#",
+            help = "The routing key used for subscribing to messages")
+    private String routingKey;
+
     public static RabbitMQSourceConfig load(String yamlFile) throws IOException {
         ObjectMapper mapper = new ObjectMapper(new YAMLFactory());
         return mapper.readValue(new File(yamlFile), RabbitMQSourceConfig.class);

--- a/pulsar-io/rabbitmq/src/main/java/org/apache/pulsar/io/rabbitmq/RabbitMQSourceConfig.java
+++ b/pulsar-io/rabbitmq/src/main/java/org/apache/pulsar/io/rabbitmq/RabbitMQSourceConfig.java
@@ -61,6 +61,24 @@ public class RabbitMQSourceConfig extends RabbitMQAbstractConfig implements Seri
             help = "Set true if the queue should be declared passively - ie to preserve durability/timeout settings")
     private boolean passive = false;
 
+    @FieldDoc(
+            required = false,
+            defaultValue = "false",
+            help = "Set true if the queue should survive a broker restart")
+    private boolean durable = false;
+
+    @FieldDoc(
+            required = false,
+            defaultValue = "false",
+            help = "Set true if the queue can be used by only one connection and get deleted when it closes")
+    private boolean exclusive = false;
+
+    @FieldDoc(
+            required = false,
+            defaultValue = "false",
+            help = "Set true if the queue should get deleted when the last consumer unsubscribes")
+    private boolean autoDelete = false;
+
     public static RabbitMQSourceConfig load(String yamlFile) throws IOException {
         ObjectMapper mapper = new ObjectMapper(new YAMLFactory());
         return mapper.readValue(new File(yamlFile), RabbitMQSourceConfig.class);

--- a/pulsar-io/rabbitmq/src/test/java/org/apache/pulsar/io/rabbitmq/source/RabbitMQSourceConfigTest.java
+++ b/pulsar-io/rabbitmq/src/test/java/org/apache/pulsar/io/rabbitmq/source/RabbitMQSourceConfigTest.java
@@ -42,6 +42,7 @@ public class RabbitMQSourceConfigTest {
         assertNotNull(config);
         assertEquals("localhost", config.getHost());
         assertEquals(Integer.parseInt("5672"), config.getPort());
+        assertEquals(false, config.isSsl());
         assertEquals("/", config.getVirtualHost());
         assertEquals("guest", config.getUsername());
         assertEquals("guest", config.getPassword());
@@ -62,6 +63,7 @@ public class RabbitMQSourceConfigTest {
         Map<String, Object> map = new HashMap<>();
         map.put("host", "localhost");
         map.put("port", "5672");
+        map.put("ssl", "false");
         map.put("virtualHost", "/");
         map.put("username", "guest");
         map.put("password", "guest");
@@ -80,6 +82,7 @@ public class RabbitMQSourceConfigTest {
         assertNotNull(config);
         assertEquals("localhost", config.getHost());
         assertEquals(Integer.parseInt("5672"), config.getPort());
+        assertEquals(false, config.isSsl());
         assertEquals("/", config.getVirtualHost());
         assertEquals("guest", config.getUsername());
         assertEquals("guest", config.getPassword());

--- a/pulsar-io/rabbitmq/src/test/resources/sourceConfig.yaml
+++ b/pulsar-io/rabbitmq/src/test/resources/sourceConfig.yaml
@@ -20,6 +20,7 @@
 {
 "host": "localhost",
 "port": "5672",
+"ssl": "false",
 "virtualHost": "/",
 "username": "guest",
 "password": "guest",


### PR DESCRIPTION
### Description

Update **RabbitMQ Source Connector** to make it more configurable and suitable for us to use it for our Betradar UOF integration.

- [x] Ability to build the RabbitMQ connector locally without installing any dependencies
- [x] Support more configuration options (SSL, queue settings, queue binding)
- [x] Improve ACKing of messages
- [x] Include queue name (and other metadata) in the Pulsar message

To build the connector, simply run `make` as follows

```
make

(...)

[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  6.221 s
[INFO] Finished at: 2023-10-01T09:25:48Z
[INFO] ------------------------------------------------------------------------
[INFO] 12 goals, 9 executed, 3 from cache, saving at least 7s
```

A successful execution should generate a `pulsar-io-rabbitmq-2.10.3.nar` file, which should be available in `pulsar-io/rabbitmq/target`. 


To create the source connector, you can use `pulsarctl` as follows

```
pulsarctl sources create --archive /path/to/pulsar-io-rabbitmq-2.10.3.nar
    --classname "org.apache.pulsar.io.rabbitmq.RabbitMQSource"
    --parallelism 1
    --tenant <pulsar-tenant>
    --namespace <pulsar-namespace>
    --name <connector-name>
    --destination-topic-name <pulsar-topic-name>
    --source-config-file /path/to/config.yaml
```

### Resources

- Official documentation about [developing Pulsar connectors](https://pulsar.apache.org/docs/3.1.x/io-develop/)
- Inspirational [blog post](https://medium.com/google-cloud/develop-pulsar-connectors-for-pub-sub-7c6cd4499877) about how to handle (source) acknowledgements to prevent data loss
- [RabbitMQ Java client documentation](https://rabbitmq.github.io/rabbitmq-java-client/api/4.x.x/com/rabbitmq/client/Channel.html)
