### PR TITLE
Update RabbitMQ Source Connector

### DIFF
--- a/.github/workflows/deploy-pulsar-source.sh
+++ b/.github/workflows/deploy-pulsar-source.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+set -euxo pipefail
+
+PULSAR_VERSION=3.0.4
+PULSAR_DESTINATION_TOPIC="persistent://${PULSAR_TENANT}/offer/betradar-feed"
+
+ls -lh ${HOME}/${PULSAR_OAUTH_KEY_FILE}
+
+function pulsar-admin() {
+    PULSAR_VERSION=${PULSAR_VERSION:-3.0.4}
+    DOCKER_IMAGE=ghcr.io/bluelabs-eu/pulsar-admin:${PULSAR_VERSION}
+    DOCKER_RUN_OPTS="--rm -i --network host -v /etc/passwd:/etc/passwd:ro -v /etc/group:/etc/group:ro -u $(id -u):$(id -g) -v ${HOME}/${PULSAR_OAUTH_KEY_FILE}:${HOME}/${PULSAR_OAUTH_KEY_FILE} -v ${HOME}/scoreboard-pulsar-function.jar:${HOME}/scoreboard-pulsar-function.jar"
+    docker run ${DOCKER_RUN_OPTS} ${DOCKER_IMAGE} "$@"
+}
+
+case ${PULSAR_ADMIN_ACTION} in
+    get)
+        pulsar-admin \
+            --admin-url ${PULSAR_ADMIN_SERVICE_URL} \
+            --auth-plugin org.apache.pulsar.client.impl.auth.oauth2.AuthenticationOAuth2 \
+            --auth-params "{\"privateKey\":\"${HOME}/${PULSAR_OAUTH_KEY_FILE}\", \"issuerUrl\":\"${PULSAR_ISSUER_URL}\", \"audience\":\"urn:sn:pulsar:${PULSAR_ORG}:${PULSAR_INSTANCE}\"}" \
+            source ${PULSAR_ADMIN_ACTION} \
+            --tenant ${PULSAR_TENANT} \
+            --namespace ${PULSAR_NAMESPACE} \
+            --name ${PULSAR_SOURCE_NAME}-${BL_OPERATOR}
+        ;;
+    delete)
+        pulsar-admin \
+            --admin-url ${PULSAR_ADMIN_SERVICE_URL} \
+            --auth-plugin org.apache.pulsar.client.impl.auth.oauth2.AuthenticationOAuth2 \
+            --auth-params "{\"privateKey\":\"${HOME}/${PULSAR_OAUTH_KEY_FILE}\", \"issuerUrl\":\"${PULSAR_ISSUER_URL}\", \"audience\":\"urn:sn:pulsar:${PULSAR_ORG}:${PULSAR_INSTANCE}\"}" \
+            source ${PULSAR_ADMIN_ACTION} \
+            --tenant ${PULSAR_TENANT} \
+            --namespace ${PULSAR_NAMESPACE} \
+            --name ${PULSAR_SOURCE_NAME}-${BL_OPERATOR}
+        ;;
+    *)
+        # deploy function
+        pulsar-admin \
+            --admin-url ${PULSAR_ADMIN_SERVICE_URL} \
+            --auth-plugin org.apache.pulsar.client.impl.auth.oauth2.AuthenticationOAuth2 \
+            --auth-params "{\"privateKey\":\"${HOME}/${PULSAR_OAUTH_KEY_FILE}\", \"issuerUrl\":\"${PULSAR_ISSUER_URL}\", \"audience\":\"urn:sn:pulsar:${PULSAR_ORG}:${PULSAR_INSTANCE}\"}" \
+            source ${PULSAR_ADMIN_ACTION} \
+            --tenant ${PULSAR_TENANT} \
+            --namespace ${PULSAR_NAMESPACE} \
+            --classname "org.apache.pulsar.io.rabbitmq.RabbitMQSource" \
+            --archive ${HOME}/pulsar-io-rabbitmq-3.3.3.nar \
+            --name ${PULSAR_SOURCE_NAME}-${BL_OPERATOR}
+            --parallelism ${PULSAR_SOURCE_PARALLELISM} \
+            --destination-topic-name ${PULSAR_DESTINATION_TOPIC}
+            --source-config "{\"configs\":{\"host\":\"${BETRADAR_AMQP_HOST}\",\"port\":\"5671\",\"virtualHost\":\"${BETRADAR_AMQP_VIRTUAL_HOST}\",\"username\":\"${BETRADAR_AMQP_USERNAME}\",\"password\":\"\",\"queueName\":\"\",\"connectionName\":\"${BETRADAR_AMQP_CONNECTION_NAME}\",\"ssl\":\"true\",\"requestedChannelMax\":\"0\",\"requestedFrameMax\":\"0\",\"connectionTimeout\":\"60000\",\"handshakeTimeout\":\"10000\",\"requestedHeartbeat\":\"60\",\"prefetchCount\":\"0\",\"prefetchGlobal\":\"false\",\"durable\":\"false\",\"exclusive\":\"true\",\"autoDelete\":\"true\",\"exchangeName\":\"unifiedfeed\"}}"
+        ;;
+esac

--- a/.github/workflows/deployment.yaml
+++ b/.github/workflows/deployment.yaml
@@ -1,0 +1,81 @@
+name: deployment
+run-name: "${{ inputs.environment }} (${{ inputs.pulsarctl-action }})  | ${{ github.ref_name }}"
+
+on:
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: 'environment'
+        required: true
+        type: choice
+        options:
+        - 'Betfox Staging'
+        - 'Bluepepper Staging'
+        - 'Rivalo Staging'
+        - 'United Staging'
+        - 'Betfox Production'
+        - 'Bluepepper Production'
+        - 'Rivalo Production'
+        - 'United Production'
+        default: 'Betfox Staging'
+      pulsar-admin-action:
+        description: 'pulsar-admin action'
+        required: true
+        type: choice
+        options:
+        - update
+        - create
+        - delete
+        - get
+        default: get
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    environment: ${{ inputs.environment }}
+    env:
+      PULSAR_ADMIN_SERVICE_URL: ${{ vars.PULSAR_ADMIN_SERVICE_URL }}
+      PULSAR_ISSUER_URL: "https://auth.streamnative.cloud/"
+      PULSAR_ORG: ${{ vars.PULSAR_ORG }}
+      PULSAR_INSTANCE: ${{ vars.PULSAR_INSTANCE }}
+      PULSAR_OAUTH_KEY_FILE: "pulsar-oauth.key"
+      PULSAR_TENANT: ${{ vars.PULSAR_TENANT }}
+      PULSAR_NAMESPACE: "offer"
+      BL_OPERATOR: ${{ vars.BL_OPERATOR }}
+      PULSAR_SOURCE_NAME: "betradar-rabbitmq"
+      PULSAR_SOURCE_PARALLELISM: "1"
+      PULSAR_ADMIN_ACTION: ${{ inputs.pulsar-admin-action }}
+      BETRADAR_AMQP_HOST: ${{ vars.BETRADAR_AMQP_HOST }}
+      BETRADAR_AMQP_VIRTUAL_HOST: ${{ vars.BETRADAR_AMQP_VIRTUAL_HOST }}
+      BETRADAR_AMQP_CONNECTION_NAME: ${{ vars.BETRADAR_AMQP_CONNECTION_NAME }}
+      BETRADAR_AMQP_USERNAME: ${{ secrets.BETRADAR_AMQP_USERNAME }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - uses: actions/setup-java@v3
+        with:
+          distribution: temurin
+          java-version: 11
+          cache: maven
+
+      - name: Build
+        run: |
+          mvn clean package -am -pl pulsar-io/rabbitmq -DskipTests
+          mv ./pulsar-io/rabbitmq/target/pulsar-io-rabbitmq-3.3.3-SNAPSHOT.nar ${HOME}/pulsar-io-rabbitmq-3.3.3.nar
+
+      - name: Download oauth key file
+        run: |
+          echo '${{ secrets.CLIENT_SA_OAUTH_KEY }}' >> ${HOME}/${{ env.PULSAR_OAUTH_KEY_FILE }}
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Deploy pulsar source
+        run: |
+          ./.github/workflows/deploy-pulsar-source.sh

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -1,0 +1,45 @@
+name: Main Pipeline
+
+on:
+  push:
+
+jobs:
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - uses: actions/setup-java@v3
+        with:
+          distribution: temurin
+          java-version: 11
+          cache: maven
+
+      - name: Test
+        run: mvn test -am -pl pulsar-io/rabbitmq
+
+  build:
+    if: contains(github.ref, 'refs/tags/')
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - uses: actions/setup-java@v3
+        with:
+          distribution: temurin
+          java-version: 11
+          cache: maven
+
+      - name: Build
+        run: mvn clean package -am -pl pulsar-io/rabbitmq -DskipTests
+
+      - name: Upload build artifact
+        uses: actions/upload-artifact@v3
+        with:
+          if-no-files-found: error
+          name: pulsar-io-rabbitmq-3.3.3-SNAPSHOT-${{ github.ref_name }}
+          path: pulsar-io/rabbitmq/target/pulsar-io-rabbitmq-3.3.3-SNAPSHOT.nar

--- a/.gitignore
+++ b/.gitignore
@@ -104,4 +104,3 @@ test-reports/
 # Emacs
 *~
 *#
->>>>>>> ac16fe8284 (chore: local, docker-based build)

--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,7 @@ nb-configuration.xml
 log/
 target/
 .mvn/wrapper/maven-wrapper.jar
+.m2
 
 # Python
 *.pyc
@@ -99,3 +100,8 @@ test-reports/
 .mvn/.gradle-enterprise/
 # Gradle Develocity
 .mvn/.develocity/
+
+# Emacs
+*~
+*#
+>>>>>>> ac16fe8284 (chore: local, docker-based build)

--- a/.rc
+++ b/.rc
@@ -1,0 +1,9 @@
+function mvn() {
+    DOCKER_IMAGE=apachepulsar/pulsar-build:ubuntu-20.04
+    DOCKER_RUN_OPTS="--rm -it --network host -v ${PWD}/.m2:/root/.m2 -v ${PWD}:${PWD} -w ${PWD} ${DOCKER_RUN_EXTRA_OPTS}"
+    if [ -n "$ZSH_VERSION" ]; then
+        docker run ${=DOCKER_RUN_OPTS} ${DOCKER_IMAGE} mvn "$@"
+    else
+        docker run ${DOCKER_RUN_OPTS} ${DOCKER_IMAGE} mvn "$@"
+    fi
+}

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,15 @@
+.PHONY: all build test clean
+
+ifndef NODOCKER
+SHELL := BASH_ENV=.rc /bin/bash --noprofile
+endif
+
+all: build test
+
+build: ; mvn clean -pl pulsar-io/rabbitmq install -DskipTests
+
+test: ; mvn -pl pulsar-io/rabbitmq test
+
+clean:
+	mvn clean
+	rm -rf .m2

--- a/pom.xml
+++ b/pom.xml
@@ -1821,6 +1821,7 @@ flexible messaging model and an intuitive client API.</description>
               <excludes>
                 <exclude>LICENSE</exclude>
                 <exclude>NOTICE</exclude>
+                <exclude>Makefile</exclude>
                 <exclude>**/*.txt</exclude>
                 <exclude>**/*.pem</exclude>
                 <exclude>**/*.crt</exclude>

--- a/pulsar-io/rabbitmq/pom.xml
+++ b/pulsar-io/rabbitmq/pom.xml
@@ -110,6 +110,16 @@
 
   <build>
     <plugins>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>${maven-compiler-plugin.version}</version>
+        <configuration>
+          <release>11</release>
+        </configuration>
+      </plugin>
+
       <plugin>
         <groupId>org.apache.nifi</groupId>
         <artifactId>nifi-nar-maven-plugin</artifactId>

--- a/pulsar-io/rabbitmq/src/main/java/org/apache/pulsar/io/rabbitmq/RabbitMQAbstractConfig.java
+++ b/pulsar-io/rabbitmq/src/main/java/org/apache/pulsar/io/rabbitmq/RabbitMQAbstractConfig.java
@@ -21,6 +21,8 @@ package org.apache.pulsar.io.rabbitmq;
 import com.google.common.base.Preconditions;
 import com.rabbitmq.client.ConnectionFactory;
 import java.io.Serializable;
+import java.security.KeyManagementException;
+import java.security.NoSuchAlgorithmException;
 import lombok.Data;
 import lombok.experimental.Accessors;
 import org.apache.pulsar.io.core.annotations.FieldDoc;
@@ -51,6 +53,12 @@ public class RabbitMQAbstractConfig implements Serializable {
         defaultValue = "5672",
         help = "The RabbitMQ port to connect to")
     private int port = 5672;
+
+    @FieldDoc(
+        required = false,
+        defaultValue = "false",
+        help = "Set to true to establish a secure connection to RabbitMQ")
+    private boolean ssl = false;
 
     @FieldDoc(
         required = true,
@@ -115,7 +123,7 @@ public class RabbitMQAbstractConfig implements Serializable {
         Preconditions.checkNotNull(connectionName, "connectionName property not set.");
     }
 
-    public ConnectionFactory createConnectionFactory() {
+    public ConnectionFactory createConnectionFactory() throws NoSuchAlgorithmException, KeyManagementException {
         ConnectionFactory connectionFactory = new ConnectionFactory();
         connectionFactory.setHost(this.host);
         connectionFactory.setUsername(this.username);
@@ -127,6 +135,9 @@ public class RabbitMQAbstractConfig implements Serializable {
         connectionFactory.setHandshakeTimeout(this.handshakeTimeout);
         connectionFactory.setRequestedHeartbeat(this.requestedHeartbeat);
         connectionFactory.setPort(this.port);
+        if (this.ssl) {
+            connectionFactory.useSslProtocol();
+        }
         return connectionFactory;
     }
 }

--- a/pulsar-io/rabbitmq/src/main/java/org/apache/pulsar/io/rabbitmq/RabbitMQSource.java
+++ b/pulsar-io/rabbitmq/src/main/java/org/apache/pulsar/io/rabbitmq/RabbitMQSource.java
@@ -89,7 +89,7 @@ public class RabbitMQSource extends PushSource<byte[]> {
             rabbitMQChannel.queueBind(queueName, exchange, routingKey);
         }
         com.rabbitmq.client.Consumer consumer = new RabbitMQConsumer(this, rabbitMQChannel);
-        rabbitMQChannel.basicConsume(rabbitMQSourceConfig.getQueueName(), consumer);
+        rabbitMQChannel.basicConsume(queueName, consumer);
         logger.info("A consumer for queue {} has been successfully started.", queueName);
     }
 

--- a/pulsar-io/rabbitmq/src/main/java/org/apache/pulsar/io/rabbitmq/RabbitMQSource.java
+++ b/pulsar-io/rabbitmq/src/main/java/org/apache/pulsar/io/rabbitmq/RabbitMQSource.java
@@ -80,6 +80,11 @@ public class RabbitMQSource extends PushSource<byte[]> {
                 rabbitMQSourceConfig.isPrefetchGlobal()
         );
         rabbitMQChannel.basicQos(rabbitMQSourceConfig.getPrefetchCount(), rabbitMQSourceConfig.isPrefetchGlobal());
+        String exchange = rabbitMQSourceConfig.getExchangeName();
+        String routingKey = rabbitMQSourceConfig.getRoutingKey();
+        if (exchange != null) {
+            rabbitMQChannel.queueBind(queueDeclaration.getQueue(), exchange, routingKey);
+        }
         com.rabbitmq.client.Consumer consumer = new RabbitMQConsumer(this, rabbitMQChannel);
         rabbitMQChannel.basicConsume(rabbitMQSourceConfig.getQueueName(), consumer);
         logger.info("A consumer for queue {} has been successfully started.", queueDeclaration.getQueue());

--- a/pulsar-io/rabbitmq/src/main/java/org/apache/pulsar/io/rabbitmq/RabbitMQSource.java
+++ b/pulsar-io/rabbitmq/src/main/java/org/apache/pulsar/io/rabbitmq/RabbitMQSource.java
@@ -64,14 +64,15 @@ public class RabbitMQSource extends PushSource<byte[]> {
                 rabbitMQConnection.getPort()
         );
         rabbitMQChannel = rabbitMQConnection.createChannel();
+        AMQP.Queue.DeclareOk queueDeclaration;
         if (rabbitMQSourceConfig.isPassive()) {
-            rabbitMQChannel.queueDeclarePassive(rabbitMQSourceConfig.getQueueName());
+            queueDeclaration = rabbitMQChannel.queueDeclarePassive(rabbitMQSourceConfig.getQueueName());
         } else {
-            rabbitMQChannel.queueDeclare(rabbitMQSourceConfig.getQueueName(),
-                                     rabbitMQSourceConfig.isDurable(),
-                                     rabbitMQSourceConfig.isExclusive(),
-                                     rabbitMQSourceConfig.isAutoDelete(),
-                                     null
+            queueDeclaration = rabbitMQChannel.queueDeclare(rabbitMQSourceConfig.getQueueName(),
+                                                        rabbitMQSourceConfig.isDurable(),
+                                                        rabbitMQSourceConfig.isExclusive(),
+                                                        rabbitMQSourceConfig.isAutoDelete(),
+                                                        null
             );
         }
         logger.info("Setting channel.basicQos({}, {}).",
@@ -81,7 +82,7 @@ public class RabbitMQSource extends PushSource<byte[]> {
         rabbitMQChannel.basicQos(rabbitMQSourceConfig.getPrefetchCount(), rabbitMQSourceConfig.isPrefetchGlobal());
         com.rabbitmq.client.Consumer consumer = new RabbitMQConsumer(this, rabbitMQChannel);
         rabbitMQChannel.basicConsume(rabbitMQSourceConfig.getQueueName(), consumer);
-        logger.info("A consumer for queue {} has been successfully started.", rabbitMQSourceConfig.getQueueName());
+        logger.info("A consumer for queue {} has been successfully started.", queueDeclaration.getQueue());
     }
 
     @Override

--- a/pulsar-io/rabbitmq/src/main/java/org/apache/pulsar/io/rabbitmq/RabbitMQSource.java
+++ b/pulsar-io/rabbitmq/src/main/java/org/apache/pulsar/io/rabbitmq/RabbitMQSource.java
@@ -67,7 +67,12 @@ public class RabbitMQSource extends PushSource<byte[]> {
         if (rabbitMQSourceConfig.isPassive()) {
             rabbitMQChannel.queueDeclarePassive(rabbitMQSourceConfig.getQueueName());
         } else {
-            rabbitMQChannel.queueDeclare(rabbitMQSourceConfig.getQueueName(), false, false, false, null);
+            rabbitMQChannel.queueDeclare(rabbitMQSourceConfig.getQueueName(),
+                                     rabbitMQSourceConfig.isDurable(),
+                                     rabbitMQSourceConfig.isExclusive(),
+                                     rabbitMQSourceConfig.isAutoDelete(),
+                                     null
+            );
         }
         logger.info("Setting channel.basicQos({}, {}).",
                 rabbitMQSourceConfig.getPrefetchCount(),

--- a/pulsar-io/rabbitmq/src/main/java/org/apache/pulsar/io/rabbitmq/RabbitMQSource.java
+++ b/pulsar-io/rabbitmq/src/main/java/org/apache/pulsar/io/rabbitmq/RabbitMQSource.java
@@ -102,11 +102,14 @@ public class RabbitMQSource extends PushSource<byte[]> {
         @Override
         public void handleDelivery(String consumerTag, Envelope envelope, AMQP.BasicProperties properties, byte[] body)
                 throws IOException {
-            source.consume(new RabbitMQRecord(Optional.ofNullable(envelope.getRoutingKey()), body));
             long deliveryTag = envelope.getDeliveryTag();
-            // positively acknowledge all deliveries up to this delivery tag to reduce network traffic
-            // since manual message acknowledgments are turned on by default
-            this.getChannel().basicAck(deliveryTag, true);
+            RabbitMQRecord record = new RabbitMQRecord(
+                                                   Optional.ofNullable(envelope.getRoutingKey()),
+                                                   body,
+                                                   this.getChannel(),
+                                                   deliveryTag
+            );
+            source.consume(record);
         }
     }
 
@@ -114,5 +117,24 @@ public class RabbitMQSource extends PushSource<byte[]> {
     private static class RabbitMQRecord implements Record<byte[]> {
         private final Optional<String> key;
         private final byte[] value;
+        private final Channel channel;
+        private final Long deliveryTag;
+
+        public void ack() {
+            try {
+                channel.basicAck(deliveryTag, true);
+            } catch (IOException e) {
+                logger.error("Failed to acknowledge message.", e);
+            }
+        }
+
+        public void fail() {
+            try {
+                channel.basicNack(deliveryTag, true, true);
+            } catch (IOException e) {
+                logger.error("Failed to negatively acknowledge message.", e);
+            }
+        }
+
     }
 }

--- a/pulsar-io/rabbitmq/src/main/java/org/apache/pulsar/io/rabbitmq/RabbitMQSourceConfig.java
+++ b/pulsar-io/rabbitmq/src/main/java/org/apache/pulsar/io/rabbitmq/RabbitMQSourceConfig.java
@@ -81,6 +81,18 @@ public class RabbitMQSourceConfig extends RabbitMQAbstractConfig implements Seri
             help = "Set true if the queue should get deleted when the last consumer unsubscribes")
     private boolean autoDelete = false;
 
+    @FieldDoc(
+        required = false,
+        defaultValue = "",
+        help = "The exchange to bind the queue on")
+    private String exchangeName;
+
+    @FieldDoc(
+            required = false,
+            defaultValue = "#",
+            help = "The routing key used for subscribing to messages")
+    private String routingKey;
+
     public static RabbitMQSourceConfig load(String yamlFile) throws IOException {
         ObjectMapper mapper = new ObjectMapper(new YAMLFactory());
         return mapper.readValue(new File(yamlFile), RabbitMQSourceConfig.class);

--- a/pulsar-io/rabbitmq/src/main/java/org/apache/pulsar/io/rabbitmq/RabbitMQSourceConfig.java
+++ b/pulsar-io/rabbitmq/src/main/java/org/apache/pulsar/io/rabbitmq/RabbitMQSourceConfig.java
@@ -63,6 +63,24 @@ public class RabbitMQSourceConfig extends RabbitMQAbstractConfig implements Seri
             help = "Set true if the queue should be declared passively - ie to preserve durability/timeout settings")
     private boolean passive = false;
 
+    @FieldDoc(
+            required = false,
+            defaultValue = "false",
+            help = "Set true if the queue should survive a broker restart")
+    private boolean durable = false;
+
+    @FieldDoc(
+            required = false,
+            defaultValue = "false",
+            help = "Set true if the queue can be used by only one connection and get deleted when it closes")
+    private boolean exclusive = false;
+
+    @FieldDoc(
+            required = false,
+            defaultValue = "false",
+            help = "Set true if the queue should get deleted when the last consumer unsubscribes")
+    private boolean autoDelete = false;
+
     public static RabbitMQSourceConfig load(String yamlFile) throws IOException {
         ObjectMapper mapper = new ObjectMapper(new YAMLFactory());
         return mapper.readValue(new File(yamlFile), RabbitMQSourceConfig.class);

--- a/pulsar-io/rabbitmq/src/test/java/org/apache/pulsar/io/rabbitmq/source/RabbitMQSourceConfigTest.java
+++ b/pulsar-io/rabbitmq/src/test/java/org/apache/pulsar/io/rabbitmq/source/RabbitMQSourceConfigTest.java
@@ -44,6 +44,7 @@ public class RabbitMQSourceConfigTest {
         assertNotNull(config);
         assertEquals("localhost", config.getHost());
         assertEquals(Integer.parseInt("5672"), config.getPort());
+        assertEquals(false, config.isSsl());
         assertEquals("/", config.getVirtualHost());
         assertEquals("guest", config.getUsername());
         assertEquals("guest", config.getPassword());
@@ -64,6 +65,7 @@ public class RabbitMQSourceConfigTest {
         Map<String, Object> map = new HashMap<>();
         map.put("host", "localhost");
         map.put("port", "5672");
+        map.put("ssl", "false");
         map.put("virtualHost", "/");
         map.put("username", "guest");
         map.put("password", "guest");
@@ -125,6 +127,7 @@ public class RabbitMQSourceConfigTest {
         assertNotNull(config);
         assertEquals("localhost", config.getHost());
         assertEquals(Integer.parseInt("5672"), config.getPort());
+        assertEquals(false, config.isSsl());
         assertEquals("/", config.getVirtualHost());
         assertEquals("guest", config.getUsername());
         assertEquals("guest", config.getPassword());

--- a/pulsar-io/rabbitmq/src/test/resources/sourceConfig.yaml
+++ b/pulsar-io/rabbitmq/src/test/resources/sourceConfig.yaml
@@ -20,6 +20,7 @@
 {
 "host": "localhost",
 "port": "5672",
+"ssl": "false",
 "virtualHost": "/",
 "username": "guest",
 "password": "guest",


### PR DESCRIPTION
### Description

Update **RabbitMQ Source Connector** to make it more configurable and suitable for us to use it for our Betradar UOF integration.

- [x] Ability to build the RabbitMQ connector locally without installing any dependencies
- [x] Support more configuration options (SSL, queue settings, queue binding)
- [x] Improve ACKing of messages
- [x] Include queue name (and other metadata) in the Pulsar message

To build the connector, simply run `make` as follows

```
make

(...)

[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  6.221 s
[INFO] Finished at: 2023-10-01T09:25:48Z
[INFO] ------------------------------------------------------------------------
[INFO] 12 goals, 9 executed, 3 from cache, saving at least 7s
```

A successful execution should generate a `pulsar-io-rabbitmq-2.10.3.nar` file, which should be available in `pulsar-io/rabbitmq/target`. 


To create the source connector, you can use `pulsarctl` as follows

```
pulsarctl sources create --archive /path/to/pulsar-io-rabbitmq-2.10.3.nar
    --classname "org.apache.pulsar.io.rabbitmq.RabbitMQSource"
    --parallelism 1
    --tenant <pulsar-tenant>
    --namespace <pulsar-namespace>
    --name <connector-name>
    --destination-topic-name <pulsar-topic-name>
    --source-config-file /path/to/config.yaml
```

### Resources

- Official documentation about [developing Pulsar connectors](https://pulsar.apache.org/docs/3.1.x/io-develop/)
- Inspirational [blog post](https://medium.com/google-cloud/develop-pulsar-connectors-for-pub-sub-7c6cd4499877) about how to handle (source) acknowledgements to prevent data loss
- [RabbitMQ Java client documentation](https://rabbitmq.github.io/rabbitmq-java-client/api/4.x.x/com/rabbitmq/client/Channel.html)
