### PR TITLE
Debezium 3.1.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -159,8 +159,8 @@ flexible messaging model and an intuitive client API.</description>
     <presto.version>332</presto.version>
     <scala.binary.version>2.13</scala.binary.version>
     <scala-library.version>2.13.10</scala-library.version>
-    <debezium.version>1.7.2.Final</debezium.version>
-    <debezium.postgresql.version>42.4.1</debezium.postgresql.version>
+    <debezium.version>3.1.0.Final</debezium.version>
+    <debezium.postgresql.version>42.6.1</debezium.postgresql.version>
     <debezium.mysql.version>8.0.28</debezium.mysql.version>
     <jsonwebtoken.version>0.11.1</jsonwebtoken.version>
     <opencensus.version>0.28.0</opencensus.version>

--- a/pulsar-io/debezium/core/src/main/java/org/apache/pulsar/io/debezium/DebeziumSource.java
+++ b/pulsar-io/debezium/core/src/main/java/org/apache/pulsar/io/debezium/DebeziumSource.java
@@ -95,6 +95,7 @@ public abstract class DebeziumSource extends KafkaConnectSource {
             config.put(PulsarDatabaseHistory.CLIENT_BUILDER.name(), pulsarClientBuilder);
         }
 
+        log.info("Debezium config: {}", config);
         super.open(config, sourceContext);
     }
 

--- a/pulsar-io/debezium/core/src/main/java/org/apache/pulsar/io/debezium/DebeziumSource.java
+++ b/pulsar-io/debezium/core/src/main/java/org/apache/pulsar/io/debezium/DebeziumSource.java
@@ -72,7 +72,7 @@ public abstract class DebeziumSource extends KafkaConnectSource {
         setConfigIfNull(config, PulsarKafkaWorkerConfig.VALUE_CONVERTER_CLASS_CONFIG, DEFAULT_CONVERTER);
 
         // database.history : implementation class for database history.
-        setConfigIfNull(config, HistorizedRelationalDatabaseConnectorConfig.DATABASE_HISTORY.name(), DEFAULT_HISTORY);
+        setConfigIfNull(config, HistorizedRelationalDatabaseConnectorConfig.SCHEMA_HISTORY.name(), DEFAULT_HISTORY);
 
         // database.history.pulsar.service.url
         String pulsarUrl = (String) config.get(PulsarDatabaseHistory.SERVICE_URL.name());

--- a/pulsar-io/debezium/core/src/main/java/org/apache/pulsar/io/debezium/PulsarDatabaseHistory.java
+++ b/pulsar-io/debezium/core/src/main/java/org/apache/pulsar/io/debezium/PulsarDatabaseHistory.java
@@ -26,12 +26,12 @@ import io.debezium.annotation.ThreadSafe;
 import io.debezium.config.Configuration;
 import io.debezium.config.Field;
 import io.debezium.document.DocumentReader;
-import io.debezium.relational.history.AbstractDatabaseHistory;
-import io.debezium.relational.history.DatabaseHistory;
-import io.debezium.relational.history.DatabaseHistoryException;
-import io.debezium.relational.history.DatabaseHistoryListener;
+import io.debezium.relational.history.AbstractSchemaHistory;
 import io.debezium.relational.history.HistoryRecord;
 import io.debezium.relational.history.HistoryRecordComparator;
+import io.debezium.relational.history.SchemaHistory;
+import io.debezium.relational.history.SchemaHistoryException;
+import io.debezium.relational.history.SchemaHistoryListener;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
@@ -51,12 +51,12 @@ import org.apache.pulsar.client.api.Reader;
 import org.apache.pulsar.client.api.Schema;
 
 /**
- * A {@link DatabaseHistory} implementation that records schema changes as normal pulsar messages on the specified
+ * A {@link SchemaHistory} implementation that records schema changes as normal pulsar messages on the specified
  * topic, and that recovers the history by establishing a Kafka Consumer re-processing all messages on that topic.
  */
 @Slf4j
 @ThreadSafe
-public final class PulsarDatabaseHistory extends AbstractDatabaseHistory {
+public final class PulsarDatabaseHistory extends AbstractSchemaHistory {
 
     public static final Field TOPIC = Field.create(CONFIGURATION_FIELD_PREFIX_STRING + "pulsar.topic")
         .withDisplayName("Database history topic name")
@@ -96,7 +96,7 @@ public final class PulsarDatabaseHistory extends AbstractDatabaseHistory {
         TOPIC,
         SERVICE_URL,
         CLIENT_BUILDER,
-        DatabaseHistory.NAME,
+        AbstractSchemaHistory.NAME,
         READER_CONFIG);
 
     private final DocumentReader reader = DocumentReader.defaultReader();
@@ -111,10 +111,10 @@ public final class PulsarDatabaseHistory extends AbstractDatabaseHistory {
     public void configure(
             Configuration config,
             HistoryRecordComparator comparator,
-            DatabaseHistoryListener listener,
+            SchemaHistoryListener listener,
             boolean useCatalogBeforeSchema) {
         super.configure(config, comparator, listener, useCatalogBeforeSchema);
-        if (!config.validateAndRecord(ALL_FIELDS, logger::error)) {
+        if (!config.validateAndRecord(ALL_FIELDS, log::error)) {
             throw new IllegalArgumentException("Error configuring an instance of "
                 + getClass().getSimpleName() + "; check the logs for details");
         }
@@ -140,7 +140,7 @@ public final class PulsarDatabaseHistory extends AbstractDatabaseHistory {
         }
 
         // Copy the relevant portions of the configuration and add useful defaults ...
-        this.dbHistoryName = config.getString(DatabaseHistory.NAME, UUID.randomUUID().toString());
+        this.dbHistoryName = config.getString(SchemaHistory.NAME, UUID.randomUUID().toString());
 
         log.info("Configure to store the debezium database history {} to pulsar topic {}",
             dbHistoryName, topicName);
@@ -193,7 +193,7 @@ public final class PulsarDatabaseHistory extends AbstractDatabaseHistory {
     }
 
     @Override
-    protected void storeRecord(HistoryRecord record) throws DatabaseHistoryException {
+    protected void storeRecord(HistoryRecord record) throws SchemaHistoryException {
         if (this.producer == null) {
             throw new IllegalStateException("No producer is available. Ensure that 'start()'"
                     + " is called before storing database history records.");
@@ -204,7 +204,7 @@ public final class PulsarDatabaseHistory extends AbstractDatabaseHistory {
         try {
             producer.send(record.toString());
         } catch (PulsarClientException e) {
-            throw new DatabaseHistoryException(e);
+            throw new SchemaHistoryException(e);
         }
     }
 

--- a/pulsar-io/debezium/core/src/test/java/org/apache/pulsar/io/debezium/PulsarDatabaseHistoryTest.java
+++ b/pulsar-io/debezium/core/src/test/java/org/apache/pulsar/io/debezium/PulsarDatabaseHistoryTest.java
@@ -27,8 +27,8 @@ import io.debezium.config.Configuration;
 import io.debezium.connector.mysql.antlr.MySqlAntlrDdlParser;
 import io.debezium.relational.Tables;
 import io.debezium.relational.ddl.DdlParser;
-import io.debezium.relational.history.DatabaseHistory;
-import io.debezium.relational.history.DatabaseHistoryListener;
+import io.debezium.relational.history.SchemaHistory;
+import io.debezium.relational.history.SchemaHistoryListener;
 import io.debezium.text.ParsingException;
 import io.debezium.util.Collect;
 
@@ -80,8 +80,8 @@ public class PulsarDatabaseHistoryTest extends ProducerConsumerBase {
     private void testHistoryTopicContent(boolean skipUnparseableDDL, boolean testWithClientBuilder, boolean testWithReaderConfig) throws Exception {
         Configuration.Builder configBuidler = Configuration.create()
                 .with(PulsarDatabaseHistory.TOPIC, topicName)
-                .with(DatabaseHistory.NAME, "my-db-history")
-                .with(DatabaseHistory.SKIP_UNPARSEABLE_DDL_STATEMENTS, skipUnparseableDDL);
+                .with(SchemaHistory.NAME, "my-db-history")
+                .with(SchemaHistory.SKIP_UNPARSEABLE_DDL_STATEMENTS, skipUnparseableDDL);
 
         if (testWithClientBuilder) {
             ClientBuilder builder = PulsarClient.builder().serviceUrl(brokerUrl.toString());
@@ -101,7 +101,7 @@ public class PulsarDatabaseHistoryTest extends ProducerConsumerBase {
         }
 
         // Start up the history ...
-        history.configure(configBuidler.build(), null, DatabaseHistoryListener.NOOP, true);
+        history.configure(configBuidler.build(), null, SchemaHistoryListener.NOOP, true);
         history.start();
 
         // Should be able to call start more than once ...
@@ -160,7 +160,7 @@ public class PulsarDatabaseHistoryTest extends ProducerConsumerBase {
         // Stop the history (which should stop the producer) ...
         history.stop();
         history = new PulsarDatabaseHistory();
-        history.configure(configBuidler.build(), null, DatabaseHistoryListener.NOOP, true);
+        history.configure(configBuidler.build(), null, SchemaHistoryListener.NOOP, true);
         // no need to start
 
         // Recover from the very beginning to just past the first change ...
@@ -240,11 +240,11 @@ public class PulsarDatabaseHistoryTest extends ProducerConsumerBase {
         Configuration config = Configuration.create()
             .with(PulsarDatabaseHistory.SERVICE_URL, brokerUrl.toString())
             .with(PulsarDatabaseHistory.TOPIC, "persistent://my-property/my-ns/dummytopic")
-            .with(DatabaseHistory.NAME, "my-db-history")
-            .with(DatabaseHistory.SKIP_UNPARSEABLE_DDL_STATEMENTS, true)
+            .with(SchemaHistory.NAME, "my-db-history")
+            .with(SchemaHistory.SKIP_UNPARSEABLE_DDL_STATEMENTS, true)
             .build();
 
-        history.configure(config, null, DatabaseHistoryListener.NOOP, true);
+        history.configure(config, null, SchemaHistoryListener.NOOP, true);
         history.start();
 
         // dummytopic should not exist yet

--- a/pulsar-io/kafka-connect-adaptor/src/main/java/org/apache/pulsar/io/kafka/connect/KafkaConnectSource.java
+++ b/pulsar-io/kafka-connect-adaptor/src/main/java/org/apache/pulsar/io/kafka/connect/KafkaConnectSource.java
@@ -20,7 +20,9 @@ package org.apache.pulsar.io.kafka.connect;
 
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
+import java.util.ArrayList;
 import java.util.Base64;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
@@ -28,6 +30,7 @@ import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.kafka.connect.json.JsonConverterConfig;
 import org.apache.kafka.connect.source.SourceRecord;
+import org.apache.kafka.connect.transforms.Transformation;
 import org.apache.pulsar.client.api.Schema;
 import org.apache.pulsar.common.schema.KeyValue;
 import org.apache.pulsar.common.schema.KeyValueEncodingType;
@@ -49,6 +52,8 @@ public class KafkaConnectSource extends AbstractKafkaConnectSource<KeyValue<byte
     private boolean jsonWithEnvelope = false;
     private static final String JSON_WITH_ENVELOPE_CONFIG = "json-with-envelope";
 
+    private List<Transformation<SourceRecord>> transformations = new ArrayList<>();
+
     public void open(Map<String, Object> config, SourceContext sourceContext) throws Exception {
         if (config.get(JSON_WITH_ENVELOPE_CONFIG) != null) {
             jsonWithEnvelope = Boolean.parseBoolean(config.get(JSON_WITH_ENVELOPE_CONFIG).toString());
@@ -57,17 +62,67 @@ public class KafkaConnectSource extends AbstractKafkaConnectSource<KeyValue<byte
             config.put(JsonConverterConfig.SCHEMAS_ENABLE_CONFIG, false);
         }
         log.info("jsonWithEnvelope: {}", jsonWithEnvelope);
+        initTransformations(config);
         super.open(config, sourceContext);
     }
 
+    // SMT support: initialize transformation list using only public API
+    private void initTransformations(Map<String, Object> config) {
+        transformations.clear();
+        Object transformsListObj = config.get("transforms");
+        if (transformsListObj != null) {
+            String transformsList = transformsListObj.toString();
+            for (String transformName : transformsList.split(",")) {
+                transformName = transformName.trim();
+                String prefix = "transforms." + transformName + ".";
+                String typeKey = prefix + "type";
+                Object classNameObj = config.get(typeKey);
+                if (classNameObj == null) continue;
+                String className = classNameObj.toString();
+                try {
+                    @SuppressWarnings("unchecked")
+                    Class<Transformation<SourceRecord>> clazz =
+                        (Class<Transformation<SourceRecord>>) Class.forName(className);
+                    Transformation<SourceRecord> transform = clazz.getDeclaredConstructor().newInstance();
+                    // Gather all properties for this transform
+                    java.util.Map<String, Object> transformConfig = config.entrySet().stream()
+                        .filter(e -> e.getKey().startsWith(prefix))
+                        .collect(java.util.stream.Collectors.toMap(
+                            e -> e.getKey().substring(prefix.length()),
+                            java.util.Map.Entry::getValue
+                        ));
+                    transform.configure(transformConfig);
+                    transformations.add(transform);
+                } catch (Exception e) {
+                    throw new RuntimeException("Failed to instantiate SMT: " + className, e);
+                }
+            }
+        }
+    }
 
-    public synchronized KafkaSourceRecord processSourceRecord(final SourceRecord srcRecord) {
-        KafkaSourceRecord record = new KafkaSourceRecord(srcRecord);
-        offsetWriter.offset(srcRecord.sourcePartition(), srcRecord.sourceOffset());
-        return record;
+    // SMT support: apply transformation list
+    private SourceRecord applyTransforms(SourceRecord record) {
+        SourceRecord current = record;
+        for (Transformation<SourceRecord> transform : transformations) {
+            if (current == null) break;
+            current = transform.apply(current);
+        }
+        return current;
     }
 
     private static final AvroData avroData = new AvroData(1000);
+
+    public synchronized KafkaSourceRecord processSourceRecord(final SourceRecord srcRecord) {
+        // Apply SMTs before further processing
+        SourceRecord transformedRecord = applyTransforms(srcRecord);
+        if (transformedRecord == null) {
+            // Record dropped by SMT
+            return null;
+        }
+        KafkaSourceRecord record = new KafkaSourceRecord(transformedRecord);
+        offsetWriter.offset(transformedRecord.sourcePartition(), transformedRecord.sourceOffset());
+        return record;
+    }
 
     private class KafkaSourceRecord extends AbstractKafkaSourceRecord<KeyValue<byte[], byte[]>>
             implements KVRecord<byte[], byte[]> {


### PR DESCRIPTION
> [!NOTE]
> This is just an experiment. I was curious about what it would take for us to upgrade to the latest stable version and what new features and improvements we would be able to tap on.

## Description

An attempt to upgrade the PostgreSQL source connector from Debezium 1.9.0 to 3.1.0.


### Testing

```
source .rc
mvn clean -pl pulsar-io/debezium/core install
```

```
[INFO] -------------------------------------------------------
[INFO]  T E S T S
[INFO] -------------------------------------------------------
[INFO] Running org.apache.pulsar.io.debezium.PulsarDatabaseHistoryTest
[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 51.2 s - in org.apache.pulsar.io.debezium.PulsarDatabaseHistoryTest
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  01:13 min
[INFO] Finished at: 2025-04-11T07:38:19Z
[INFO] ------------------------------------------------------------------------
```

The changes seem to work (as in they don't break the tests 😄). As a next step, it would be interesting to see if the feature set got richer too. For example, allowing us to use topic routing as described [here](https://debezium.io/documentation/reference/stable/transformations/topic-routing.html), which is what would give us built-in support for working with partitioned tables

> **Partitioned PostgreSQL tables**
> When the Debezium PostgreSQL connector captures changes in a partitioned table, the default behavior is that change event records are routed to a different topic for each partition. To emit records from all partitions to one topic, configure the topic routing SMT. Because each key in a partitioned table is guaranteed to be unique, configure [key.enforce.uniqueness=false](https://debezium.io/documentation/reference/stable/transformations/topic-routing.html#by-logical-table-router-key-enforce-uniqueness) so that the SMT does not add a key field to ensure unique keys. The addition of a key field is default behavior.


